### PR TITLE
fxkSQL

### DIFF
--- a/Server/Java/code/mysql.sql
+++ b/Server/Java/code/mysql.sql
@@ -22,7 +22,7 @@ CREATE TABLE `class_infos` (
   `rong_cloud_id` varchar(256) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_create_at` (`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 
 CREATE TABLE `doc_infos` (


### PR DESCRIPTION
对SQL文件进行了修复，可以直接在数据库下运行生成表。
之前确实一个分号，在MySQL8.0无法直接运行。